### PR TITLE
Add Events Checks

### DIFF
--- a/test/cure.ts
+++ b/test/cure.ts
@@ -3,7 +3,15 @@ import { expect } from 'chai';
 import hre, { starknet } from 'hardhat';
 import fs from 'fs';
 
-import { l2Eth, simpleDeployL2, l2String, l2Address, invoke } from './utils';
+import {
+  l2Eth,
+  simpleDeployL2,
+  l2String,
+  l2Address,
+  invoke,
+  IEventDataEntry,
+  assertEvent,
+} from './utils';
 
 // https://github.com/makerdao/xdomain-dss/blob/add-end/src/test/Cure.t.sol
 // #commit#9e7834c57918bfaa23522d8402c78e21a920a00a
@@ -175,7 +183,10 @@ describe('cure', async function () {
       },
       hre
     );
-    await invoke(admin, cure, 'lift', { src: addr1 });
+    let txHash = await invoke(admin, cure, 'lift', { src: addr1 });
+    let liftReceipt = await starknet.getTransactionReceipt(txHash);
+    let liftReceiptData: IEventDataEntry[] = [{ data: addr1, isAddress: true }];
+    assertEvent(liftReceipt, 'Lift', liftReceiptData);
     expect((await cure.call('tCount')).res).to.equal(1n);
     // address addr2 = address(new SourceMock(0));
     // vm.expectEmit(true, true, true, true);
@@ -189,7 +200,10 @@ describe('cure', async function () {
       },
       hre
     );
-    await invoke(admin, cure, 'lift', { src: addr2 });
+    txHash = await invoke(admin, cure, 'lift', { src: addr2 });
+    liftReceipt = await starknet.getTransactionReceipt(txHash);
+    liftReceiptData = [{ data: addr2, isAddress: true }];
+    assertEvent(liftReceipt, 'Lift', liftReceiptData);
     expect((await cure.call('tCount')).res).to.equal(2n);
 
     // address addr3 = address(new SourceMock(0));
@@ -224,7 +238,10 @@ describe('cure', async function () {
     // assertEq(cure.pos(addr1), 1);
     // assertEq(cure.srcs(1), addr2);
     // assertEq(cure.pos(addr2), 2);
-    await invoke(admin, cure, 'drop', { src: addr3 });
+    txHash = await invoke(admin, cure, 'drop', { src: addr3 });
+    let dropReceipt = await starknet.getTransactionReceipt(txHash);
+    let dropReceiptData: IEventDataEntry[] = [{ data: addr3, isAddress: true }];
+    assertEvent(dropReceipt, 'Drop', dropReceiptData);
     expect((await cure.call('tCount')).res).to.equal(2n);
     expect(l2Address((await cure.call('srcs', { index: 0n })).res)).to.equal(addr1);
     expect((await cure.call('pos', { src: addr1 })).res).to.equal(1n);
@@ -240,7 +257,10 @@ describe('cure', async function () {
     // assertEq(cure.pos(addr2), 2);
     // assertEq(cure.srcs(2), addr3);
     // assertEq(cure.pos(addr3), 3);
-    await invoke(admin, cure, 'lift', { src: addr3 });
+    txHash = await invoke(admin, cure, 'lift', { src: addr3 });
+    liftReceipt = await starknet.getTransactionReceipt(txHash);
+    liftReceiptData = [{ data: addr3, isAddress: true }];
+    assertEvent(liftReceipt, 'Lift', liftReceiptData);
     expect((await cure.call('tCount')).res).to.equal(3n);
 
     expect(l2Address((await cure.call('srcs', { index: 0n })).res)).to.equal(addr1);
@@ -257,7 +277,10 @@ describe('cure', async function () {
     // assertEq(cure.pos(addr3), 1);
     // assertEq(cure.srcs(1), addr2);
     // assertEq(cure.pos(addr2), 2);
-    await invoke(admin, cure, 'drop', { src: addr1 });
+    txHash = await invoke(admin, cure, 'drop', { src: addr1 });
+    dropReceipt = await starknet.getTransactionReceipt(txHash);
+    dropReceiptData = [{ data: addr1, isAddress: true }];
+    assertEvent(dropReceipt, 'Drop', dropReceiptData);
     expect((await cure.call('tCount')).res).to.equal(2n);
     expect(l2Address((await cure.call('srcs', { index: 0n })).res)).to.equal(addr3);
     expect((await cure.call('pos', { src: addr3 })).res).to.equal(1n);
@@ -266,7 +289,10 @@ describe('cure', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Lift(addr1);
     // cure.lift(addr1);
-    await invoke(admin, cure, 'lift', { src: addr1 });
+    txHash = await invoke(admin, cure, 'lift', { src: addr1 });
+    liftReceipt = await starknet.getTransactionReceipt(txHash);
+    liftReceiptData = [{ data: addr1, isAddress: true }];
+    assertEvent(liftReceipt, 'Lift', liftReceiptData);
     expect((await cure.call('tCount')).res).to.equal(3n);
     // assertEq(cure.tCount(), 3);
     // assertEq(cure.srcs(0), addr3);
@@ -292,7 +318,10 @@ describe('cure', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Lift(addr4);
     // cure.lift(addr4);
-    await invoke(admin, cure, 'lift', { src: addr4 });
+    txHash = await invoke(admin, cure, 'lift', { src: addr4 });
+    liftReceipt = await starknet.getTransactionReceipt(txHash);
+    liftReceiptData = [{ data: addr4, isAddress: true }];
+    assertEvent(liftReceipt, 'Lift', liftReceiptData);
     // assertEq(cure.tCount(), 4);
     expect((await cure.call('tCount')).res).to.equal(4n);
     // assertEq(cure.srcs(0), addr3);
@@ -314,7 +343,10 @@ describe('cure', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Drop(addr2);
     // cure.drop(addr2);
-    await invoke(admin, cure, 'drop', { src: addr2 });
+    txHash = await invoke(admin, cure, 'drop', { src: addr2 });
+    dropReceipt = await starknet.getTransactionReceipt(txHash);
+    dropReceiptData = [{ data: addr2, isAddress: true }];
+    assertEvent(dropReceipt, 'Drop', dropReceiptData);
     expect((await cure.call('tCount')).res).to.equal(3n);
     // assertEq(cure.tCount(), 3);
     // assertEq(cure.srcs(0), addr3);
@@ -401,9 +433,10 @@ describe('cure', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Cage();
     // cure.cage();
-    await invoke(admin, cure, 'cage');
+    let txHash = await invoke(admin, cure, 'cage');
+    const cageReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(cageReceipt, 'Cage', []);
     // assertEq(cure.live(), 0);
-
     expect((await cure.call('live')).res).to.equal(0n);
   });
 
@@ -665,7 +698,11 @@ describe('cure', async function () {
     // cure.load(source2);
     // assertEq(cure.lCount(), 2);
     // assertEq(cure.tell(), 5_000);
-    await invoke(admin, cure, 'load', { src: source1.address });
+    let txHash = await invoke(admin, cure, 'load', { src: source1.address });
+    let loadReceipt = await starknet.getTransactionReceipt(txHash);
+    let loadReceiptData: IEventDataEntry[] = [{ data: source1.address, isAddress: true }];
+    assertEvent(loadReceipt, 'Load', loadReceiptData);
+
     expect((await cure.call('lCount')).res).to.equal(1n);
     await invoke(admin, cure, 'load', { src: source2.address });
     expect((await cure.call('lCount')).res).to.equal(2n);

--- a/test/end.ts
+++ b/test/end.ts
@@ -16,6 +16,7 @@ import {
   ray,
   wad,
   rad,
+  assertEvent,
 } from './utils';
 import fs from 'fs';
 
@@ -461,7 +462,9 @@ describe('end', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Cage();
     // end.cage();
-    await invoke(admin, end, 'cage');
+    let txHash = await invoke(admin, end, 'cage');
+    const cageReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(cageReceipt, 'Cage', []);
     // assertEq(end.live(), 0);
     // assertEq(vat.live(), 0);
     // assertEq(pot.live(), 0);
@@ -517,12 +520,20 @@ describe('end', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Cage("gold");
     // end.cage("gold");
-    await invoke(admin, end, 'cage_ilk', { ilk: l2String('gold') });
+    let txHash = await invoke(admin, end, 'cage_ilk', { ilk: l2String('gold') });
+    let cageReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(cageReceipt, 'Cage_ilk', [{ data: l2String('gold') }]);
     // vm.expectEmit(true, true, true, true);
     // emit Skim("gold", urn1, 3 ether, 15 ether);
     // end.skim("gold", urn1);
-    await invoke(admin, end, 'skim', { ilk: l2String('gold'), urn: urn1 });
-
+    txHash = await invoke(admin, end, 'skim', { ilk: l2String('gold'), urn: urn1 });
+    let skimReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(skimReceipt, 'Skim', [
+      { data: l2String('gold') },
+      { data: urn1, isAddress: true },
+      { data: eth('3').toBigInt() },
+      { data: eth('15').toBigInt() },
+    ]);
     // // local checks:
     // assertEq(art("gold", urn1), 0);
     // assertEq(ink("gold", urn1), 7 ether);
@@ -545,7 +556,13 @@ describe('end', async function () {
     // assertEq(ink("gold", urn1), 0);
     // assertEq(gem("gold", urn1), 7 ether);
     // ali.exit(gold.gemA, address(this), 7 ether);
-    await invoke(ali, end, 'free', { ilk: l2String('gold') });
+    txHash = await invoke(ali, end, 'free', { ilk: l2String('gold') });
+    let freeReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(freeReceipt, 'Free', [
+      { data: l2String('gold') },
+      { data: ali.address, isAddress: true },
+      { data: eth('7').toBigInt() },
+    ]);
     expect(await ink('gold', urn1)).to.deep.equal(rad(0n));
     expect(await gem('gold', urn1)).to.deep.equal(uint(eth('7').toBigInt()));
     await invoke(ali, gold.gemA, 'exit', { user: _admin, wad: l2Eth(eth('7')).res });
@@ -555,11 +572,15 @@ describe('end', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Thaw();
     // end.thaw();
-    await invoke(admin, end, 'thaw');
+    txHash = await invoke(admin, end, 'thaw');
+    let thawReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(thawReceipt, 'Thaw', []);
     // vm.expectEmit(true, true, true, true);
     // emit Flow("gold");
     // end.flow("gold");
-    await invoke(admin, end, 'flow', { ilk: l2String('gold') });
+    txHash = await invoke(admin, end, 'flow', { ilk: l2String('gold') });
+    let flowReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(flowReceipt, 'Flow', [{ data: l2String('gold') }]);
     // assertTrue(end.fix("gold") != 0);
     expect(await end.call('fix', { ilk: l2String('gold') })).to.not.be.deep.equal(l2Eth(0n));
     // // dai redemption
@@ -573,7 +594,12 @@ describe('end', async function () {
       amount: l2Eth(eth('15')).res,
     });
     await approveClaim(ali, end.address, eth('15'));
-    await invoke(ali, end, 'pack', { wad: l2Eth(eth('15')).res });
+    txHash = await invoke(ali, end, 'pack', { wad: l2Eth(eth('15')).res });
+    let packReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(packReceipt, 'Pack', [
+      { data: ali.address, isAddress: true },
+      { data: eth('15').toBigInt() },
+    ]);
     // // global checks:
     // assertEq(vat.debt(), rad(15 ether));
     // assertEq(vat.vice(), rad(15 ether));
@@ -590,8 +616,13 @@ describe('end', async function () {
     // vm.expectEmit(true, true, true, true);
     // emit Cash("gold", address(ali), 15 ether);
     // ali.cash("gold", 15 ether);
-    await invoke(ali, end, 'cash', { ilk: l2String('gold'), wad: l2Eth(eth('15')).res });
-
+    txHash = await invoke(ali, end, 'cash', { ilk: l2String('gold'), wad: l2Eth(eth('15')).res });
+    let cashReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(cashReceipt, 'Cash', [
+      { data: l2String('gold') },
+      { data: ali.address, isAddress: true },
+      { data: eth('15').toBigInt() },
+    ]);
     // // local checks:
     // assertEq(dai(urn1), 15 ether);
     // assertEq(gem("gold", urn1), 3 ether);

--- a/test/vat.ts
+++ b/test/vat.ts
@@ -18,6 +18,7 @@ import {
   uint,
   SplitUintType,
   neg,
+  assertEvent,
 } from './utils';
 import fs from 'fs';
 
@@ -102,13 +103,15 @@ describe('vat', async function () {
       // Update value
       // vm.expectEmit(true, false, false, true);
       // emit File(valueB32, newData);
-      await invoke(admin, base, 'file', {
+      let txHash = await invoke(admin, base, 'file', {
         what: l2String(values[i]),
         data: {
           low: newData.toDec()[0],
           high: newData.toDec()[1],
         },
       });
+      let fileReceipt = await starknet.getTransactionReceipt(txHash);
+      assertEvent(fileReceipt, 'File', [{ data: l2String(values[i]) }, { data: newData.res }]);
 
       // Confirm it was updated successfully
       const { [values[i]]: _data } = await base.call(values[i]);
@@ -118,13 +121,15 @@ describe('vat', async function () {
       // Reset value to original
       // vm.expectEmit(true, false, false, true);
       // emit File(valueB32, origData);
-      await invoke(admin, base, 'file', {
+      txHash = await invoke(admin, base, 'file', {
         what: l2String(values[i]),
         data: {
           low: origData.toDec()[0],
           high: origData.toDec()[0],
         },
       });
+      fileReceipt = await starknet.getTransactionReceipt(txHash);
+      assertEvent(fileReceipt, 'File', [{ data: l2String(values[i]) }, { data: origData.res }]);
     }
 
     // Finally check that file is authed
@@ -204,7 +209,16 @@ describe('vat', async function () {
     dink: SplitUintType<bigint>,
     dart: SplitUintType<bigint>
   ) {
-    await invoke(user, vat, 'frob', { i, u, v, w, dink, dart });
+    let txHash = await invoke(user, vat, 'frob', { i, u, v, w, dink, dart });
+    const frobReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(frobReceipt, 'Frob', [
+      { data: ILK },
+      { data: u, isAddress: true },
+      { data: v, isAddress: true },
+      { data: w, isAddress: true },
+      { data: dink },
+      { data: dart },
+    ]);
   }
 
   async function fork(
@@ -215,7 +229,15 @@ describe('vat', async function () {
     dink: SplitUintType<bigint>,
     dart: SplitUintType<bigint>
   ) {
-    await invoke(user, vat, 'fork', { ilk, src, dst, dink, dart });
+    let txHash = await invoke(user, vat, 'fork', { ilk, src, dst, dink, dart });
+    const forkReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(forkReceipt, 'Fork', [
+      { data: ilk },
+      { data: src, isAddress: true },
+      { data: dst, isAddress: true },
+      { data: dink },
+      { data: dart },
+    ]);
   }
 
   async function grab(
@@ -227,23 +249,47 @@ describe('vat', async function () {
     dink: SplitUintType<bigint>,
     dart: SplitUintType<bigint>
   ) {
-    await invoke(admin, vat, 'grab', { i, u, v, w, dink, dart });
+    let txHash = await invoke(admin, vat, 'grab', { i, u, v, w, dink, dart });
+    const grabReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(grabReceipt, 'Grab', [
+      { data: i },
+      { data: u, isAddress: true },
+      { data: v, isAddress: true },
+      { data: w, isAddress: true },
+      { data: dink },
+      { data: dart },
+    ]);
   }
 
   async function suck(u: any, v: any, rad: SplitUintType<bigint>) {
-    await invoke(admin, vat, 'suck', { u, v, rad });
+    let txHash = await invoke(admin, vat, 'suck', { u, v, rad });
+    const suckReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(suckReceipt, 'Fork', [
+      { data: u, isAddress: true },
+      { data: v, isAddress: true },
+      { data: rad },
+    ]);
   }
 
   async function fold(i: any, u: any, rate: SplitUintType<bigint>) {
-    await invoke(admin, vat, 'fold', { i, u, rate });
+    let txHash = await invoke(admin, vat, 'fold', { i, u, rate });
+    const foldReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(foldReceipt, 'Fold', [{ data: i }, { data: u, isAddress: true }, { data: rate }]);
   }
 
   async function hope(from: Account, to: string) {
-    await invoke(from, vat, 'hope', { user: to });
+    let txHash = await invoke(from, vat, 'hope', { user: to });
+    const hopeReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(hopeReceipt, 'Hope', [
+      { data: from.address, isAddress: true },
+      { data: to, isAddress: true },
+    ]);
   }
 
   async function heal(from: Account, rad: SplitUintType<bigint>) {
-    await invoke(from, vat, 'heal', { rad });
+    let txHash = await invoke(from, vat, 'heal', { rad });
+    const healReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(healReceipt, 'Fork', [{ data: from.address, isAddress: true }, { data: rad }]);
   }
 
   it('test constructor', async () => {
@@ -262,11 +308,13 @@ describe('vat', async function () {
   it('test file ilk', async () => {
     // vm.expectEmit(true, true, true, true);
     // emit File(ILK, "spot", 1);
-    await invoke(admin, vat, 'file_ilk', {
+    let txHash = await invoke(admin, vat, 'file_ilk', {
       ilk: ILK,
       what: spot,
       data: uint(1n),
     });
+    const fileReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(fileReceipt, 'File_ilk', [{ data: ILK }, { data: spot }, { data: uint(1n) }]);
     expect((await vat.call('ilks', { i: ILK })).ilk.spot).to.deep.equal(uint(1n));
     await invoke(admin, vat, 'file_ilk', {
       ilk: ILK,
@@ -370,7 +418,9 @@ describe('vat', async function () {
 
     // vm.expectEmit(true, true, true, true);
     // emit Init(ILK);
-    await invoke(admin, vat, 'init', { ilk: ILK });
+    let txHash = await invoke(admin, vat, 'init', { ilk: ILK });
+    let initReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(initReceipt, 'Init', [{ data: ILK }]);
 
     // console.log(RAY);
     // console.log(SplitUint.fromUint(RAY).res);
@@ -390,7 +440,9 @@ describe('vat', async function () {
 
     // vm.expectEmit(true, true, true, true);
     // emit Cage();
-    await invoke(admin, vat, 'cage');
+    let txHash = await invoke(admin, vat, 'cage');
+    const cageReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(cageReceipt, 'Cage', []);
 
     expect((await vat.call('live')).live).to.equal(0n);
   });
@@ -407,7 +459,12 @@ describe('vat', async function () {
 
     // vm.expectEmit(true, true, true, true);
     // emit Hope(address(this), TEST_ADDRESS);
-    await vat.call('hope', { user: TEST_ADDRESS });
+    let txHash = await vat.call('hope', { user: TEST_ADDRESS });
+    const hopeReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(hopeReceipt, 'Hope', [
+      { data: _admin, isAddress: true },
+      { data: TEST_ADDRESS, isAddress: true },
+    ]);
 
     expect(
       (
@@ -433,7 +490,12 @@ describe('vat', async function () {
 
     // vm.expectEmit(true, true, true, true);
     // emit Nope(address(this), TEST_ADDRESS);
-    await invoke(admin, vat, 'nope', { user: TEST_ADDRESS });
+    let txHash = await invoke(admin, vat, 'nope', { user: TEST_ADDRESS });
+    const nopeReceipt = await starknet.getTransactionReceipt(txHash);
+    assertEvent(nopeReceipt, 'Nope', [
+      { data: _admin, isAddress: true },
+      { data: TEST_ADDRESS, isAddress: true },
+    ]);
 
     expect(
       (
@@ -451,11 +513,17 @@ describe('vat', async function () {
 
       // vm.expectEmit(true, true, true, true);
       // emit Slip(ILK, TEST_ADDRESS, int256(100 * WAD));
-      await invoke(admin, vat, 'slip', {
+      let txHash = await invoke(admin, vat, 'slip', {
         ilk: ILK,
         usr: TEST_ADDRESS,
         wad: wad(100n),
       });
+      const slipReceipt = await starknet.getTransactionReceipt(txHash);
+      assertEvent(slipReceipt, 'Slip', [
+        { data: ILK },
+        { data: TEST_ADDRESS, isAddress: true },
+        { data: wad(100n) },
+      ]);
 
       expect((await vat.call('gem', { i: ILK, u: TEST_ADDRESS })).gem).to.deep.equal(wad(100n));
     });
@@ -472,11 +540,17 @@ describe('vat', async function () {
       // vm.expectEmit(true, true, true, true);
       // emit Slip(ILK, TEST_ADDRESS, -int256(50 * WAD));
       // vat.slip(ILK, TEST_ADDRESS, -int256(50 * WAD));
-      await invoke(admin, vat, 'slip', {
+      let txHash = await invoke(admin, vat, 'slip', {
         ilk: ILK,
         usr: TEST_ADDRESS,
         wad: SplitUint.fromUint(neg(50n * WAD)).res,
       });
+      const slipReceipt = await starknet.getTransactionReceipt(txHash);
+      assertEvent(slipReceipt, 'Slip', [
+        { data: ILK },
+        { data: TEST_ADDRESS, isAddress: true },
+        { data: SplitUint.fromUint(neg(50n * WAD)).res },
+      ]);
 
       // assertEq(vat.gem(ILK, TEST_ADDRESS), 50 * WAD);
       expect((await vat.call('gem', { i: ILK, u: TEST_ADDRESS })).gem).to.deep.equal(
@@ -512,12 +586,19 @@ describe('vat', async function () {
 
       // vm.expectEmit(true, true, true, true);
       // emit Flux(ILK, ausr1, ausr2, 100 * WAD);
-      await invoke(user1, vat, 'flux', {
+      let txHash = await invoke(user1, vat, 'flux', {
         ilk: ILK,
         src: _user1,
         dst: _user2,
         wad: wad(100n),
       });
+      const fluxReceipt = await starknet.getTransactionReceipt(txHash);
+      assertEvent(fluxReceipt, 'Flux', [
+        { data: ILK },
+        { data: _user1, isAddress: true },
+        { data: _user2, isAddress: true },
+        { data: wad(100n) },
+      ]);
 
       expect((await vat.call('gem', { i: ILK, u: _user1 })).gem).to.deep.equal(uint(0n));
       expect((await vat.call('gem', { i: ILK, u: _user2 })).gem).to.deep.equal(wad(100n));
@@ -606,7 +687,17 @@ describe('vat', async function () {
       // vm.expectEmit(true, true, true, true);
       // emit Move(ausr1, ausr2, 100 * RAD);
       // usr1.move(ausr1, ausr2, 100 * RAD);
-      await invoke(user1, vat, 'move', { src: _user1, dst: _user2, rad: uint(100n * RAD) });
+      let txHash = await invoke(user1, vat, 'move', {
+        src: _user1,
+        dst: _user2,
+        rad: uint(100n * RAD),
+      });
+      const moveReceipt = await starknet.getTransactionReceipt(txHash);
+      assertEvent(moveReceipt, 'Move', [
+        { data: _user1, isAddress: true },
+        { data: _user2, isAddress: true },
+        { data: uint(100n * RAD) },
+      ]);
       // assertEq(vat.dai(ausr1), 0);
       expect((await vat.call('dai', { u: _user1 })).res).to.deep.equal(uint(0n));
       // assertEq(vat.dai(ausr2), 100 * RAD);


### PR DESCRIPTION
Add missing events checks using the following format :
```js
let txHash = await invoke(from, vat, 'hope', { user: to });
const hopeReceipt = await starknet.getTransactionReceipt(txHash);
assertEvent(hopeReceipt, 'Hope', [
      { data: from.address, isAddress: true },
      { data: to, isAddress: true },
]);
```